### PR TITLE
cabal: disallow unordered-containers < 0.2.5.0

### DIFF
--- a/taggy-lens.cabal
+++ b/taggy-lens.cabal
@@ -65,7 +65,7 @@ library
     lens >= 4,
     taggy >= 0.1,
     text,
-    unordered-containers
+    unordered-containers >= 0.2.5.0
   hs-source-dirs:
     src
   default-language:
@@ -86,7 +86,7 @@ test-suite spec
     taggy,
     text,
     lens >= 4,
-    unordered-containers,
+    unordered-containers >= 0.2.5.0,
     hspec
   default-language:
     Haskell2010
@@ -103,7 +103,7 @@ test-suite doctests
   ghc-options:
     -threaded
   build-depends:
-    base >= 4.5 && < 5, 
+    base >= 4.5 && < 5,
     doctest
   default-language:
     Haskell2010


### PR DESCRIPTION
Earlier versions of unordered-containers had a faulty
Show instance that made the doctests fail
(since 37ec59e4d5573677ba6a30550d7a8808de37def3).

The Show instance was fixed here:
https://github.com/tibbe/unordered-containers/commit/d7b09ed10b40a4734eba27ae8c812e8114e074b7
