### PR TITLE
fix compile error with lens >= 5

### DIFF
--- a/src/Text/Taggy/Lens.hs
+++ b/src/Text/Taggy/Lens.hs
@@ -102,7 +102,7 @@ attrs f el = f (eltAttrs el) <&> \as -> el {eltAttrs=as}
 -- ["a","b"]
 
 attr :: Text -> Lens' Element (Maybe Text)
-attr = fmap attrs . at
+attr k = attrs . at k
 
 -- | A traversal into attributes matching a provided property.
 --


### PR DESCRIPTION
Compiling taggy-lens with lens >= 5 results in:

```
Building library for taggy-lens-0.1.2..
[1 of 1] Compiling Text.Taggy.Lens  ( src/Text/Taggy/Lens.hs, dist/build/Text/Taggy/Lens.o, dist/build/Text/Taggy/Lens.dyn_o )

src/Text/Taggy/Lens.hs:105:8: error:
    • Couldn't match type: f0 (Element -> f1 Element)
                     with: forall (f :: * -> *).
                           Functor f =>
                           (Maybe Text -> f (Maybe Text)) -> Element -> f Element
      Expected: Text -> Lens' Element (Maybe Text)
        Actual: Text -> f0 (Element -> f1 Element)
    • In the expression: fmap attrs . at
      In an equation for ‘attr’: attr = fmap attrs . at
    |
105 | attr = fmap attrs . at
    |        ^^^^^^^^^^^^^^^

src/Text/Taggy/Lens.hs:105:21: error:
    • Couldn't match type: forall (f :: * -> *).
                           Functor f =>
                           (Maybe (Control.Lens.At.IxValue m0)
                            -> f (Maybe (Control.Lens.At.IxValue m0)))
                           -> m0 -> f m0
                     with: f0 (HashMap Text Text -> f1 (HashMap Text Text))
      Expected: Text -> f0 (HashMap Text Text -> f1 (HashMap Text Text))
        Actual: Control.Lens.At.Index m0
                -> Lens' m0 (Maybe (Control.Lens.At.IxValue m0))
    • In the second argument of ‘(.)’, namely ‘at’
      In the expression: fmap attrs . at
      In an equation for ‘attr’: attr = fmap attrs . at
    |
105 | attr = fmap attrs . at
```

Which is also why `taggy-lens` is currently marked as broken in
nixpkgs.  I'm not totally sure why this fixes it, but I confirmed that
it works now with both lens >= 5 and below.